### PR TITLE
Adding speaker session for 2025

### DIFF
--- a/app/content/talks/2025/speaker-alexander-delgado.mdx
+++ b/app/content/talks/2025/speaker-alexander-delgado.mdx
@@ -1,0 +1,23 @@
+---
+title: "Relational Databases and Data Warehouses: A Practical Overview"
+date: 2025-03-05
+author: "Josef Sieber"
+intro: "Explore the fundamental distinctions between Relational Databases and Data Warehouses"
+eventImage: "https://secure.meetupstatic.com/photos/event/2/a/d/highres_522240685.webp"
+---
+## Details
+In this tech session, we will explore the fundamental distinctions between Relational Databases and Data Warehouses, shedding light on crucial concepts like row store and column store. We will delve into the physical storage of data on disk and examine how it influences performance.
+
+Whether you're a seasoned professional or just starting your journey in the world of data, by understanding the contrasting characteristics of these two types of systems, this talk will provide valuable insights into the core principles that drive modern data storage and retrieval systems. Attendees will leave with a deeper understanding of how to choose the right tools for their specific data needs and performance requirements.
+
+## Speakers
+**Alexander Delgado**
+![](https://secure-content.meetupstatic.com/images/classic-events/522240557/200x200.webp)
+Alex Delgado is a highly skilled Certified Public Accountant (CPA) and Senior Manager in the Data Engineering team at PwC. With expertise in accounting principles and regulations, he designs and implements data engineering solutions to optimize financial processes and drive business growth. He excels in developing scalable data pipelines, automating workflows, and ensuring data quality. Alex's strong analytical skills and attention to detail enable him to extract valuable insights from complex datasets. With a commitment to continuous learning, Alex remains at the forefront of data engineering advancements, making him a valuable asset to PwC's Data Engineering team.
+
+## Location
+**Vaco Tampa Skycenter** · 5411 Skycenter Dr Suite 675 · Tampa, FL
+
+### Links
+- [Check out on Meetup!](https://www.meetup.com/tampadevs/events/302146772/)
+- [Connect Alexander Delgado with on linkedin!](https://www.linkedin.com/in/alexander-delgado-cpa-cisa-59288044/)

--- a/app/content/talks/2025/speaker-aniruth-narayanan.mdx
+++ b/app/content/talks/2025/speaker-aniruth-narayanan.mdx
@@ -1,0 +1,25 @@
+---
+title: "Fishing for AI-Powered Insights: Lakehouse Technologies"
+date: 2025-01-07
+author: "Josef Sieber"
+intro: "ML algorithms, and data lakes"
+eventImage: "https://secure.meetupstatic.com/photos/event/f/5/e/highres_525363934.webp"
+---
+## Details
+In the past decade, companies have been focusing on machine learning powered insights to drive their businesses forward. Recently, there has been a focus on agentic AI with LLMs trained on proprietary company data. To train these models, companies have turned to data lake technologies to address the exponential growth of data and the need for more flexible, scalable data management solutions. Many modern ML algorithms and architectures (neural networks, transformers, backpropagation, LSTMs) have been around for decades, but require a massive amount of data to train. 
+
+The volume, variety, and velocity of data required for modern ML have outpaced traditional data storage and processing systems. Data lakes offer a compelling solution by providing a centralized repository capable of storing vast amounts of raw, unstructured, and semi-structured data in native formats, well-suited for machine learning and artificial intelligence tasks.
+
+In this session, we will discuss data lake technologies. We will cover the history of relational databases, data warehouses, ML algorithms, and data lakes. We will also dive into technical details of table formats like ACID guarantees of Delta Lake and Apache Iceberg, the underlying file formats like Apache Parquet, and how they come together to create the lakehouse for ML and AI.
+
+## Speaker
+**Aniruth Narayanan**  
+![](https://secure-content.meetupstatic.com/images/classic-events/525109788/200x200.webp)
+Aniruth Narayanan is a Product Manager on the Storage team at Databricks, the Data and AI company. Aniruth focuses on interoperable, open data infrastructure with Delta Lake and Apache Iceberg. Aniruth is an award winning public speaker, a former computer science instructor, and an avid basketball fan. Previously, Aniruth worked at Tesla (Software Release), Microsoft (Data Centers), Retool (Database/API Connectors), and Ernst & Young (ML Cybersecurity). You can read more about Aniruth at aniruthn.com.
+
+## Location
+**GuidePoint Security** · 3030 N Rocky Point Drive · Suite 600 · Tampa, FL
+
+### Links
+- [Check out on Meetup!](https://www.meetup.com/tampadevs/events/304210306/)
+- [Connect with Aniruth Narayanan on linkedin!](https://www.linkedin.com/in/aniruth-n)

--- a/app/content/talks/2025/speaker-forum-cloud-unveil.mdx
+++ b/app/content/talks/2025/speaker-forum-cloud-unveil.mdx
@@ -1,0 +1,27 @@
+---
+title: "Tampa Devs (Pre-alpha) Cloud Unveil + Intro to Kubernetes "
+date: 2025-10-14
+author: "Tampa Devs"
+intro: "Tampa Devs is proud to unveil the Tampa Devs Cloud"
+youtubeId: w__mr9pDgr8 
+---
+![](https://secure.meetupstatic.com/photos/event/1/6/1/4/highres_530645652.webp)
+
+As developers, our journey often starts with a laptop and a late-night idea—but where it goes from there depends on the tools, resources, and community we surround ourselves with. Tampa Devs is proud to unveil the Tampa Devs Cloud: a community-powered cloud platform built by developers, for developers. This new initiative empowers local technologists to run real-world workloads beyond the limitations of their local machines—unlocking opportunities to experiment, deploy, and scale applications in a shared cloud environment.
+
+But this launch is more than just infrastructure—it's a milestone in our story. What began as a meetup and have grown into a vibrant, collaborative tech community. The Tampa Devs Cloud is a symbol of that evolution a platform that fosters learning, collaboration, and innovation for everyone from students to seasoned engineers. 
+
+## Speakers
+**Justin Herron**  
+Justin Herron serves as the Principal Cloud Architect for the Tampa Devs Community Cloud. He is a Navy veteran with a passion for leveraging technology to help others succeed. Herron is the driving force behind the Tampa Devs Public Cloud Project, which aims to provide free cloud infrastructure access to local schools and universities. His background includes experience as a data center engineer and network engineer.
+
+**Bryan Benway**  
+With over 20 years of experience in technical pre-sales, consulting, and complex implementations, Bryan specializes in unlocking the "art of the possible" for contact centers. His career has evolved from deep infrastructure and network engineering to architecting cloud communications, and now, working in product strategy building AI-driven solutions.
+
+## Location
+**Hays** · 4350 W Cypress Suite 1000 · Tampa · FL
+
+### Links
+- [Check out on Meetup!](https://www.meetup.com/tampadevs/events/311468558/)
+- [Connect with Bryan Bennway on linkedin!](https://www.linkedin.com/in/bryanbenway/)
+- [Connect with Justin Herron on linkedin!](https://www.linkedin.com/in/desyncit/)

--- a/app/content/talks/2025/speaker-hunter-goram.mdx
+++ b/app/content/talks/2025/speaker-hunter-goram.mdx
@@ -1,0 +1,22 @@
+---
+title: "Vibe Coding Gotchas"
+date: 2025-07-23
+author: "Tampa Devs"
+intro: "How to (& not) 10X Your Way into a Brick Wall Using AI!"
+eventImage: "https://secure.meetupstatic.com/photos/event/5/e/9/9/highres_529104217.webp"
+---
+![](https://secure.meetupstatic.com/photos/event/4/3/0/1/highres_533357153.webp)
+
+## Details
+In the era of AI-driven development, it's never been easier to speed toward failure at unprecedented speeds. This talk reveals how teams unintentionally leverage powerful AI tools to accelerate mistakes, amplify technical debt, and crash projects spectacularly. More importantly, you'll discover how to shift your approach, turning AI from a runaway train into your team's greatest asset for boosting productivity and avoiding pitfalls.
+
+![](https://secure.meetupstatic.com/photos/event/4/3/0/2/highres_533357154.webp)
+
+## Speakers
+![](https://secure-content.meetupstatic.com/images/classic-events/529102517/200x200.webp)
+Upon graduating from Florida State University in May 2024, Hunter quickly sharpened his software prowess through impactful internships at Raymond James and Keysight Technologies. 
+Driven by a passion for community and innovation
+
+### Links
+- [Check out on Meetup!](https://www.meetup.com/tampadevs/events/308764488/)
+- [Connect with Hunter Goram on linkedin!](https://www.linkedin.com/in/huntergoram/)

--- a/app/content/talks/2025/speaker-jeremy-rivera.mdx
+++ b/app/content/talks/2025/speaker-jeremy-rivera.mdx
@@ -1,0 +1,27 @@
+---
+title: "Building Accessible Web Apps: Practical Solutions for Inclusive Design"
+date: 2025-06-04
+author: "Nelson Yee"
+intro: "A crucial part of building inclusive web applications"
+eventImage: "https://secure.meetupstatic.com/photos/event/4/d/e/f/highres_528319951.webp"
+---
+<iframe width="560" height="315" src="https://www.youtube.com/embed/TdnllTiGqzc?si=G-P3rJpZVFyDMrjG" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+## Details
+
+Accessibility is a crucial part of building inclusive web applications, but typically takes a back seat when developing web apps. In this session, you’ll learn how to identify common accessibility pitfalls and implement practical strategies to overcome them. 
+
+Discover tools like axe DevTools and eslint-plugin-jsx-a11y, explore best practices for keyboard navigation, focus management, and ARIA roles, and see how accessible component libraries can simplify your work. By the end, you’ll have insights to build web apps that are not only functional but truly accessible, so everyone can enjoy!
+
+[Building accessible apps with Next.js and axe DevTools](https://www.deque.com/blog/building-accessible-apps-with-next-js-and-axe-devtools/)
+
+## Sponsors
+- **Accusoft** 
+- **Deque**
+
+## Location
+**Accusoft** · 4001 N Riverside Dr · Tampa · FL
+
+### Links
+- [Check out on Meetup!](https://www.meetup.com/tampadevs/events/308006529/)
+- [Connect with Jeremy Rivera on Linkedin]

--- a/app/content/talks/2025/speaker-nathan-reller.mdx
+++ b/app/content/talks/2025/speaker-nathan-reller.mdx
@@ -1,0 +1,31 @@
+---
+title: "Introduction to Rust"
+date: 2025-04-02
+author: "Josef Sieber"
+intro: "Why should you take the time to learn another programming language when there are so many?"
+eventImage: "https://secure-content.meetupstatic.com/images/classic-events/525122790/highres.jpg"
+---
+![](https://secure.meetupstatic.com/photos/event/4/2/5/8/event_533356984.webp)
+## Details
+Learning a new programming language is difficult and time consuming. Why should you take the time to learn another programming language when there are so many urgent needs in your life? Because your career and business depend upon you writing performant and secure code. Come learn how Rust’s performance and security properties will help you and why Rust is becoming one of the most loved programming languages. In this session led by Nathan Reller, creator of Ginger OS (a Rust-based Linux distribution), learn how Rust can help your career and business. In this session you will learn:
+
+* The reasons why Rust is a great choice for your next programming assignment
+* How to build and compile a Hello World Rust program
+* How Rust can be used in a wide range of applications from bootloaders, kernels, command line interfaces, RESTful applications, and more
+
+About:
+At **Ginger Cybersecurity**, we are passionate about DevOps and cybersecurity. Our vision is to easily enable all businesses to defend themselves from cyberattacks. We provide software tools that allow DevOps engineers to create micro virtual machines that bake-in cybersecurity protections and integrate with our endpoint detection system.
+
+## Speaker
+**Nathan Reller**
+![](https://secure-content.meetupstatic.com/images/classic-events/527106996/200x200.webp)
+Founder, Ginger Cybersecurity
+
+Nathan Reller is the founder of Ginger Cybersecurity. Ginger Cybersecurity is a tech startup focused on easily enabling all businesses to defend themselves from and respond to cyberattacks in the cloud. Nathan is responsible for the development of their endpoint detection system.
+
+## Location
+**GuidePoint Security** · 3030 N Rocky Point Drive, Suite 600 · Tampa, FL
+
+### Links
+- [Check out on Meetup!](https://www.meetup.com/tampadevs/events/304515561/)
+- [Connect with Nathan Reller on linkedin!](https://www.linkedin.com/in/nathanreller/)

--- a/app/content/talks/2025/speaker-rich-winslow.mdx
+++ b/app/content/talks/2025/speaker-rich-winslow.mdx
@@ -1,0 +1,28 @@
+---
+title: "Intro to Data Engineering"
+date: 2025-02-05
+author: "Josef Sieber"
+intro: "A primer"
+eventImage: "https://secure.meetupstatic.com/photos/event/1/b/0/highres_522240432.webp"
+---
+![](https://secure.meetupstatic.com/photos/event/6/d/3/c/highres_526107964.webp)
+
+## Details
+Data is the secret sauce that we use to measure impact and drive success at our companies. We hoard as much of it as we can with the goals to make sense of it and extract value. But delivering on that promise isn't so simple. If data science is where the data is analyzed, data engineering is how it gets there.
+
+Join Rich Winslow, CTO at Tetricus Labs, and a data engineer/scientist with 20 years of experience handling and managing data, to learn how to approach data engineering problems practically and ask the right questions. You'll also hear his personal anecdotes that drive home what can go right and wrong when deploying your own solutions.
+
+## Sponsors
+- [KForce](https://www.kforce.com/)
+- [xByte Hosting](https://www.xbytecloud.com/)
+
+## Speaker
+**Rich Winslow**  
+Rich Winslow loves working on difficult problems. He is a data scientist with a background in classical mechanical engineering, device design, and project management, with a heavy dose of web and software development to satisfy whatever specifications a project requires. He is comfortable wearing a lot of different hats and can change them as needed. Rich Winslow is currently the CTO at [Tetricus Labs](https://www.tetricuslabs.com/)
+
+## Location
+[Kforce](https://embarccollective.com/) · 1150 Assembly Dr Suite 500 · Tampa, FL
+
+### Links
+- [Check out on Meetup!](https://www.meetup.com/tampadevs/events/302145600/)
+- [Connect with Rich Winslow on linkedin!](https://www.linkedin.com/in/rwinslow/) 


### PR DESCRIPTION
Added talks

1. Jan 7, 2025 - Fishing for AI-Powered Insights: Lakehouse Technologies (Aniruth Narayanan)
2. Feb 5, 2025 - Intro to Data Engineering (Rich Winslow)
3. Mar 5, 2025 - Relational Databases and Data Warehouses: A Practical Overview (Alexander Delgado)
4. Apr 2, 2025 - Introduction to Rust (Nathan Reller)
5. Jun 4, 2025 - Building Accessible Web Apps: Practical Solutions for Inclusive Design (Jeremy Rivera)
6. Jul 23, 2025 - Vibe Coding Gotchas (Hunter Goram)
7. Oct 14, 2025 - Tampa Devs (Pre-alpha) Cloud Unveil + Intro to Kubernetes (Justin Herron & Bryan Benway)